### PR TITLE
Removed babel-polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
   "plugins": [
     "transform-es2015-modules-commonjs",
     "transform-react-display-name",
-    "transform-class-properties"
+    "transform-class-properties",
+    "transform-runtime"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /lib
 /node_modules
+/yarn-error.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.0
+- Removed "babel-runtime" from compilation to fix errors related to duplicate instances.
+
 # 1.0.1
 - Added `.npmignore` to fix published version.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-react-display-name": "^6.25.0",
-    "babel-polyfill": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spunky",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Lifecycle management for react-redux",
   "main": "lib/index.js",
   "repository": "https://github.com/neoverse/spunky",

--- a/test/helpers/boot.js
+++ b/test/helpers/boot.js
@@ -1,4 +1,3 @@
-require('babel-polyfill');
 require('babel-register')({ ignore: /node_modules/ });
 
 const path = require('path');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 module.exports = (env) => {
   const isProduction = env && env.prod;
   const config = {
-    entry: ['babel-polyfill', './src/index.js'],
+    entry: ['./src/index.js'],
     target: 'web',
     mode: isProduction ? 'production' : 'development',
     output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,6 +935,12 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
By including babel-polyfill when compiling the package, it's possible that users of the package will run into this error:

> Only one instance of babel-polyfill is allowed

By replacing babel-polyfill with the transform-runtime babel plugin, we can still build properly without running into this error.