### PR TITLE
Updated to not clean previous data/error store data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.1
+- Updated store to maintain previous `data` or `error` value when progress changes to LOADED or
+  FAILED.  Without this, the `alreadyLoadedStrategy` won't work as expected due to intermittent
+  failures.
+
 # 1.1.0
 - Removed "babel-runtime" from compilation to fix errors related to duplicate instances.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spunky",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Lifecycle management for react-redux",
   "main": "lib/index.js",
   "repository": "https://github.com/neoverse/spunky",

--- a/src/reducers/actionReducer.js
+++ b/src/reducers/actionReducer.js
@@ -32,9 +32,9 @@ function reduceAction(state: State = initialState, actionState: ActionState): Ob
     case ACTION_CALL:
       return { ...state, progress: LOADING, rollbackProgress: state.progress };
     case ACTION_SUCCESS:
-      return { ...state, progress: LOADED, rollbackProgress: LOADED, error: null, data: actionState.payload, loadedCount: state.loadedCount + 1 };
+      return { ...state, progress: LOADED, rollbackProgress: LOADED, data: actionState.payload, loadedCount: state.loadedCount + 1 };
     case ACTION_FAILURE:
-      return { ...state, progress: FAILED, rollbackProgress: FAILED, data: null, error: actionState.payload };
+      return { ...state, progress: FAILED, rollbackProgress: FAILED, error: actionState.payload };
     case ACTION_RESET:
       return { ...state, ...initialState };
     case ACTION_CANCEL:


### PR DESCRIPTION
This fixes an issue with the `alreadyLoadedStrategy`.