### PR TITLE
Added the recentlyCompletedStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.2
+- Added `recentlyCompletedStrategy`.
+
 # 1.1.1
 - Updated store to maintain previous `data` or `error` value when progress changes to LOADED or
   FAILED.  Without this, the `alreadyLoadedStrategy` won't work as expected due to intermittent

--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@ export default withProgress(profileActions)(MyComponent);
 The `initiallyLoadedStrategy` is the default strategy.  It:
 
 * returns `FAILED` if any actions have failed,
-* returns `LOADING` if any actions are loading or haven't started loading,
 * returns `LOADED` if all actions have loaded.
+* returns `LOADING` if any actions are loading or haven't started loading,
 
 ```js
 import { initiallyLoadedStrategy } from "spunky";
@@ -342,13 +342,21 @@ import { initiallyLoadedStrategy } from "spunky";
 The `alreadyLoadedStrategy`:
 
 * returns `FAILED` if any actions have failed,
-* returns `LOADING` if any actions hasn't finished loading *for the first time*.
 * returns `LOADED` if all actions have loaded *at least once*, even if it has been called (is
   loading) again,
+* returns `LOADING` if any actions hasn't finished loading *for the first time*.
 
 ```js
 import { alreadyLoadedStrategy } from "spunky";
 ```
+
+##### Recently Completed Strategy
+
+The `recentlyCompletedStrategy`:
+
+* returns `FAILED` if any actions are failed or are loading but failed before the most recent load,
+* returns `LOADED` if all actions are loaded or are loading but loaded before the most recent load,
+* returns `LOADING` if any actions are loading and have not previously loaded or failed.
 
 #### Custom Strategy
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spunky",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Lifecycle management for react-redux",
   "main": "lib/index.js",
   "repository": "https://github.com/neoverse/spunky",

--- a/src/hocs/progressStrategies/recentlyCompletedStrategy.js
+++ b/src/hocs/progressStrategies/recentlyCompletedStrategy.js
@@ -1,0 +1,33 @@
+// @flow
+import { some, every } from 'lodash';
+
+import { type Progress } from '../../values/types';
+import { INITIAL, LOADING, LOADED, FAILED } from '../../values/progress';
+
+function isLoading(actionState: Object) {
+  return actionState.progress === INITIAL || actionState.progress === LOADING;
+}
+
+function wasRecently(actionState: Object, progress: string) {
+  return actionState.progress === progress || (
+    isLoading(actionState) && actionState.rollbackProgress === progress
+  );
+}
+
+function anyRecentlyFailed(actionStates: Array<Object>): boolean {
+  return some(actionStates, (actionState) => wasRecently(actionState, FAILED));
+}
+
+function allRecentlyLoaded(actionStates: Array<Object>): boolean {
+  return every(actionStates, (actionState) => wasRecently(actionState, LOADED));
+}
+
+export default function recentlyCompletedStrategy(actions: Array<Object>): Progress {
+  if (anyRecentlyFailed(actions)) {
+    return FAILED;
+  } else if (allRecentlyLoaded(actions) && actions.length > 0) {
+    return LOADED;
+  } else {
+    return LOADING;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -21,5 +21,6 @@ export { default as withCancel } from './hocs/withCancel';
 
 export { default as initiallyLoadedStrategy } from './hocs/progressStrategies/initiallyLoadedStrategy';
 export { default as alreadyLoadedStrategy } from './hocs/progressStrategies/alreadyLoadedStrategy';
+export { default as recentlyCompletedStrategy } from './hocs/progressStrategies/recentlyCompletedStrategy';
 
 export type { Actions, Progress } from './values/types';


### PR DESCRIPTION
This adds a new `recentlyCompletedStrategy` for calculating progress within components.  This is useful for when you want to pass the most recent result of a call (loaded or failed) while essentially ignoring if it's loading in a subsequent call.