### PR TITLE
Added support for nested store keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,14 +205,20 @@ export default createActions("geocode", ({ latitude, longitude }) => async () =>
 #### createBatchActions
 
 The `createBatchActions` function is useful when you want to call multiple functions in parallel, or
-if you want to display a loading component until all actions are finished loading.  This function
-accepts an object as its only argument, where each key represents an identifier for data, errors,
-etc., and each value is a set of actions created via `createActions` or `createBatchActions`.
+if you want to display a loading component until all actions are finished loading.  It accepts as
+arguments:
+
+1. `id`: Unique string representing the key in the redux store.  If multiple actions have the same
+   `id`, then performing one action will overwrite the results of the other.  Including periods
+   (`.`) will result in a nested object structure within the redux store (e.g.: `foo.bar` will
+   create an object with key `foo` that has a nested object under key `bar`).
+1. `actionsMap`: an object where each key represents an identifier for data, errors, etc., and each
+   value is a set of actions created via `createActions` or `createBatchActions`.
 
 ```js
 import { createBatchActions } from "spunky";
 
-export default createBatchActions({
+export default createBatchActions("account", {
   profile: profileActions,
   friends: friendsActions
 });

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ Actions can be called, reset, and cancelled.
 To create a set of actions, use the `createActions` function.  It accepts as arguments:
 
 1. `id`: Unique string representing the key in the redux store.  If multiple actions have the same
-   `id`, then performing one action will overwrite the results of the other.
+   `id`, then performing one action will overwrite the results of the other.  Including periods
+   (`.`) will result in a nested object structure within the redux store (e.g.: `foo.bar` will
+   create an object with key `foo` nesting an object with key `bar`).
 1. `action`: Function to be called when dispatching the action.
 
 Calling `createActions` will generate a simple object with the following shape:

--- a/src/reducers/actionReducer.js
+++ b/src/reducers/actionReducer.js
@@ -1,4 +1,6 @@
 // @flow
+import { get, set } from 'lodash';
+
 import {
   ACTION_CALL,
   ACTION_SUCCESS,
@@ -48,10 +50,7 @@ export default function actionReducer(state: Object = {}, actionState: ActionSta
   const { id, type } = actionState.meta;
 
   if (type) {
-    return {
-      ...state,
-      [id]: reduceAction(state[id], actionState)
-    };
+    return set({ ...state }, id, reduceAction(get(state, id), actionState));
   } else {
     return state;
   }

--- a/src/reducers/batchReducer.js
+++ b/src/reducers/batchReducer.js
@@ -1,5 +1,5 @@
 // @flow
-import { get, mapValues } from 'lodash';
+import { get, set, mapValues } from 'lodash';
 
 import { BATCH_CALL } from '../values/api';
 import { type ActionState } from '../values/types';
@@ -37,10 +37,7 @@ export default function batchReducer(state: Object = {}, actionState: ActionStat
   const { id, type } = actionState.meta;
 
   if (type) {
-    return {
-      ...state,
-      [id]: reduceBatch(state[id], actionState)
-    };
+    return set({ ...state }, id, reduceBatch(get(state, id), actionState));
   } else {
     return state;
   }


### PR DESCRIPTION
This adds support for nested store keys.  By passing an `id` like "foo.bar", it will appear in the store under `{ foo: { bar: ... } }`.