### PR TITLE
Added clean action

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,8 +500,8 @@ export default withReset(profileActions, (prevProps, nextProps) => {
 
 #### withActions
 
-The `withActions` HOC is used for passing the `call`, `cancel`, and/or `reset` function definitions
-for an action to your component.
+The `withActions` HOC is used for passing the `call`, `cancel`, `reset`, and/or `clean` function
+definitions for an action to your component.
 
 | Argument            | Type       | Required | Description
 | ------------------- | ---------- | -------- | -----------
@@ -516,7 +516,8 @@ export default withActions(profileActions)(MyComponent);
 export default withActions(profileActions, (actions, ownProps) => ({
   request: actions.call,
   abort: actions.cancel,
-  clean: actions.reset
+  reset: actions.reset,
+  clean: actions.clean
 }))(MyComponent);
 ```
 

--- a/src/hocs/withActions.js
+++ b/src/hocs/withActions.js
@@ -9,7 +9,8 @@ import { type Actions } from '../values/types';
 const defaultMapActionsToProps = (actions: Actions, _props: Object): Object => ({
   call: actions.call,
   cancel: actions.cancel,
-  reset: actions.reset
+  reset: actions.reset,
+  clean: actions.clean
 });
 
 const createMapDispatchToProps = (actions: Actions, mapActionsToProps: Function): Object => {

--- a/src/reducers/actionReducer.js
+++ b/src/reducers/actionReducer.js
@@ -1,12 +1,13 @@
 // @flow
-import { get, set } from 'lodash';
+import { get, set, unset } from 'lodash';
 
 import {
   ACTION_CALL,
   ACTION_SUCCESS,
   ACTION_FAILURE,
   ACTION_RESET,
-  ACTION_CANCEL
+  ACTION_CANCEL,
+  ACTION_CLEAN
 } from '../values/api';
 import { INITIAL, LOADING, LOADED, FAILED } from '../values/progress';
 import { type Data, type Error, type ActionState, type Progress } from '../values/types';
@@ -49,7 +50,9 @@ function reduceAction(state: State = initialState, actionState: ActionState): Ob
 export default function actionReducer(state: Object = {}, actionState: ActionState): Object {
   const { id, type } = actionState.meta;
 
-  if (type) {
+  if (type === ACTION_CLEAN) {
+    return unset({ ...state }, id);
+  } else if (type) {
     return set({ ...state }, id, reduceAction(get(state, id), actionState));
   } else {
     return state;

--- a/src/reducers/batchReducer.js
+++ b/src/reducers/batchReducer.js
@@ -1,7 +1,7 @@
 // @flow
-import { get, set, mapValues } from 'lodash';
+import { get, set, unset, mapValues } from 'lodash';
 
-import { BATCH_CALL } from '../values/api';
+import { BATCH_CALL, BATCH_CLEAN } from '../values/api';
 import { type ActionState } from '../values/types';
 
 type State = {
@@ -36,7 +36,9 @@ function reduceBatch(state: State = initialState, actionState: ActionState): Obj
 export default function batchReducer(state: Object = {}, actionState: ActionState): Object {
   const { id, type } = actionState.meta;
 
-  if (type) {
+  if (type === BATCH_CLEAN) {
+    return unset({ ...state }, id);
+  } else if (type) {
     return set({ ...state }, id, reduceBatch(get(state, id), actionState));
   } else {
     return state;

--- a/src/sagas/actionSaga.js
+++ b/src/sagas/actionSaga.js
@@ -3,7 +3,13 @@ import { call, put, race, take } from 'redux-saga/effects';
 import { delay, type Saga } from 'redux-saga';
 
 import { actionMatcher } from '../util/matchers';
-import { ACTION_SUCCESS, ACTION_FAILURE, ACTION_RESET, ACTION_CANCEL } from '../values/api';
+import {
+  ACTION_SUCCESS,
+  ACTION_FAILURE,
+  ACTION_RESET,
+  ACTION_CANCEL,
+  ACTION_CLEAN
+} from '../values/api';
 import {
   type Error,
   type Payload,
@@ -57,7 +63,8 @@ export default function* actionSaga(state: Object, actionState: ActionState): Sa
   yield race({
     call: call(sagaActions.request, state, actionState.payload, sagaActions),
     cancel: take(actionMatcher(ACTION_CANCEL, id)),
-    reset: take(actionMatcher(ACTION_RESET, id))
+    reset: take(actionMatcher(ACTION_RESET, id)),
+    clean: take(actionMatcher(ACTION_CLEAN, id))
   });
 
   return true;

--- a/src/sagas/batchSaga.js
+++ b/src/sagas/batchSaga.js
@@ -4,7 +4,13 @@ import { put, take, race, all, call } from 'redux-saga/effects';
 import { type Saga } from 'redux-saga';
 
 import { actionMatcher } from '../util/matchers';
-import { BATCH_SUCCESS, BATCH_FAILURE, BATCH_RESET, BATCH_CANCEL } from '../values/api';
+import {
+  BATCH_SUCCESS,
+  BATCH_FAILURE,
+  BATCH_RESET,
+  BATCH_CANCEL,
+  BATCH_CLEAN
+} from '../values/api';
 import {
   type Error,
   type ActionMeta,
@@ -65,7 +71,8 @@ export default function* batchSaga(state: Object, actionState: ActionState): Sag
   yield race({
     call: call(sagaActions.request, state, payload.calls, sagaActions),
     cancel: take(actionMatcher(BATCH_CANCEL, id)),
-    reset: take(actionMatcher(BATCH_RESET, id))
+    reset: take(actionMatcher(BATCH_RESET, id)),
+    clean: take(actionMatcher(BATCH_CLEAN, id))
   });
 
   return true;

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -5,13 +5,13 @@ import { type Saga } from 'redux-saga';
 import batchSaga from './batchSaga';
 import actionSaga from './actionSaga';
 import { actionTypeMatcher } from '../util/matchers';
-import { ACTION_CALL, BATCH_CALL, BATCH_RESET, BATCH_CANCEL } from '../values/api';
+import { ACTION_CALL, BATCH_CALL, BATCH_RESET, BATCH_CANCEL, BATCH_CLEAN } from '../values/api';
 import { type ActionState } from '../values/types';
 
 const createMatchers = (actionTypes) => actionTypes.map(actionTypeMatcher);
 
 const actionMatchers = createMatchers([ACTION_CALL]);
-const batchMatchers = createMatchers([BATCH_CALL, BATCH_RESET, BATCH_CANCEL]);
+const batchMatchers = createMatchers([BATCH_CALL, BATCH_RESET, BATCH_CANCEL, BATCH_CLEAN]);
 
 function action(actionState: ActionState) {
   return actionMatchers.some((matcher) => matcher(actionState));

--- a/src/util/createActions.js
+++ b/src/util/createActions.js
@@ -4,7 +4,8 @@ import {
   ACTION_CANCEL,
   ACTION_SUCCESS,
   ACTION_FAILURE,
-  ACTION_RESET
+  ACTION_RESET,
+  ACTION_CLEAN
 } from '../values/api';
 import { type Actions, type ActionState, type ActionTypeMap } from '../values/types';
 
@@ -13,7 +14,8 @@ const createActionTypes = (statePath: string): ActionTypeMap => ({
   CANCEL: `${statePath}/${ACTION_CANCEL}`,
   SUCCESS: `${statePath}/${ACTION_SUCCESS}`,
   FAILURE: `${statePath}/${ACTION_FAILURE}`,
-  RESET: `${statePath}/${ACTION_RESET}`
+  RESET: `${statePath}/${ACTION_RESET}`,
+  CLEAN: `${statePath}/${ACTION_CLEAN}`
 });
 
 export default function createActions(id: string, createAdaptor: Function): Actions {
@@ -38,5 +40,11 @@ export default function createActions(id: string, createAdaptor: Function): Acti
     meta: { type: ACTION_RESET, id }
   });
 
-  return { id, call, cancel, reset, actionTypes };
+  const clean = (): ActionState => ({
+    batch: false,
+    type: actionTypes.CLEAN,
+    meta: { type: ACTION_CLEAN, id }
+  });
+
+  return { id, call, cancel, reset, clean, actionTypes };
 }

--- a/src/util/createBatchActions.js
+++ b/src/util/createBatchActions.js
@@ -6,7 +6,8 @@ import {
   BATCH_CANCEL,
   BATCH_SUCCESS,
   BATCH_FAILURE,
-  BATCH_RESET
+  BATCH_RESET,
+  BATCH_CLEAN
 } from '../values/api';
 
 import {
@@ -22,7 +23,8 @@ const actionTypes: ActionTypeMap = {
   CANCEL: BATCH_CANCEL,
   SUCCESS: BATCH_SUCCESS,
   FAILURE: BATCH_FAILURE,
-  RESET: BATCH_RESET
+  RESET: BATCH_RESET,
+  CLEAN: BATCH_CLEAN
 };
 
 function mapActions(
@@ -55,5 +57,12 @@ export default function createBatchActions(id: string, actionsMap: Object): Acti
     payload: { calls: mapActions(actionsMap, 'reset') }
   });
 
-  return { id, call, cancel, reset, actionTypes };
+  const clean = (): ActionState => ({
+    batch: true,
+    type: actionTypes.CLEAN,
+    meta: { type: BATCH_CLEAN, id },
+    payload: { calls: mapActions(actionsMap, 'clean') }
+  });
+
+  return { id, call, cancel, reset, clean, actionTypes };
 }

--- a/src/values/api.js
+++ b/src/values/api.js
@@ -6,9 +6,11 @@ export const ACTION_CANCEL: ActionType = 'ACTION/CANCEL';
 export const ACTION_SUCCESS: ActionType = 'ACTION/SUCCESS';
 export const ACTION_FAILURE: ActionType = 'ACTION/FAILURE';
 export const ACTION_RESET: ActionType = 'ACTION/RESET';
+export const ACTION_CLEAN: ActionType = 'ACTION/CLEAN';
 
 export const BATCH_CALL: ActionType = 'BATCH/CALL';
 export const BATCH_CANCEL: ActionType = 'BATCH/CANCEL';
 export const BATCH_SUCCESS: ActionType = 'BATCH/SUCCESS';
 export const BATCH_FAILURE: ActionType = 'BATCH/FAILURE';
 export const BATCH_RESET: ActionType = 'BATCH/RESET';
+export const BATCH_CLEAN: ActionType = 'BATCH/CLEAN';

--- a/src/values/types.js
+++ b/src/values/types.js
@@ -2,8 +2,8 @@
 export type Progress = 'INITIAL' | 'LOADING' | 'LOADED' | 'FAILED';
 
 export type ActionType =
-  'ACTION/CALL' | 'ACTION/CANCEL' | 'ACTION/SUCCESS' | 'ACTION/FAILURE' | 'ACTION/RESET' |
-  'BATCH/CALL' | 'BATCH/CANCEL' | 'BATCH/SUCCESS' | 'BATCH/FAILURE' | 'BATCH/RESET';
+  'ACTION/CALL' | 'ACTION/CANCEL' | 'ACTION/SUCCESS' | 'ACTION/FAILURE' | 'ACTION/RESET' | 'ACTION/CLEAN' |
+  'BATCH/CALL' | 'BATCH/CANCEL' | 'BATCH/SUCCESS' | 'BATCH/FAILURE' | 'BATCH/RESET' | 'BATCH/CLEAN';
 
 export type Data = ?Object;
 export type Error = ?string;
@@ -14,10 +14,11 @@ export type ActionTypeMap = {
   CANCEL: string,
   SUCCESS: string,
   FAILURE: string,
-  RESET: string
+  RESET: string,
+  CLEAN: string
 };
 
-export type ActionName = 'call' | 'cancel' | 'reset';
+export type ActionName = 'call' | 'cancel' | 'reset' | 'clean';
 
 export type Actions = {
   id: string,

--- a/test/sagas/actionSaga.test.js
+++ b/test/sagas/actionSaga.test.js
@@ -5,7 +5,7 @@ import { call, take } from 'redux-saga/effects';
 import actionSaga, { createSagaActions } from 'sagas/actionSaga';
 import createActions from 'util/createActions';
 import { actionMatcher } from 'util/matchers';
-import { ACTION_RESET, ACTION_CANCEL } from '../../src/values/api';
+import { ACTION_RESET, ACTION_CANCEL, ACTION_CLEAN } from '../../src/values/api';
 
 describe('actionSaga', () => {
   const ID = 'TEST';
@@ -19,7 +19,7 @@ describe('actionSaga', () => {
     expect(Object.keys(step)).to.deep.equal(['@@redux-saga/IO', 'RACE']);
     expect(step['@@redux-saga/IO']).to.be.true();
 
-    const raceKeys = ['call', 'cancel', 'reset'];
+    const raceKeys = ['call', 'cancel', 'reset', 'clean'];
     expect(Object.keys(step.RACE)).to.deep.equal(raceKeys);
     raceKeys.forEach((key) => {
       expect(step.RACE[key]).to.be.instanceOf(Object);
@@ -80,6 +80,23 @@ describe('actionSaga', () => {
       const invalidAction = { type: 'INVALID' };
       expect(cancelState.pattern(invalidAction)).to.be.false();
       expect(cancelState.pattern(invalidAction)).to.equal(cancel.TAKE.pattern(invalidAction));
+    });
+  });
+
+  describe('clean action', () => {
+    const cleanState = step.RACE.clean.TAKE;
+    const clean = take(actionMatcher(ACTION_CLEAN, ID));
+
+    it('performs valid actions', () => {
+      const validAction = actions.clean();
+      expect(cleanState.pattern(validAction)).to.be.true();
+      expect(cleanState.pattern(validAction)).to.equal(clean.TAKE.pattern(validAction));
+    });
+
+    it('does not perform invalid actions', () => {
+      const invalidAction = { type: 'INVALID' };
+      expect(cleanState.pattern(invalidAction)).to.be.false();
+      expect(cleanState.pattern(invalidAction)).to.equal(clean.TAKE.pattern(invalidAction));
     });
   });
 });

--- a/test/util/createActions.test.js
+++ b/test/util/createActions.test.js
@@ -16,7 +16,8 @@ describe('createActions', () => {
       RESET: 'TEST/ACTION/RESET',
       CANCEL: 'TEST/ACTION/CANCEL',
       SUCCESS: 'TEST/ACTION/SUCCESS',
-      FAILURE: 'TEST/ACTION/FAILURE'
+      FAILURE: 'TEST/ACTION/FAILURE',
+      CLEAN: 'TEST/ACTION/CLEAN'
     });
   });
 
@@ -45,6 +46,14 @@ describe('createActions', () => {
       batch: false,
       type: 'TEST/ACTION/CANCEL',
       meta: { id: ID, type: 'ACTION/CANCEL' }
+    });
+  });
+
+  it('defines a clean function', () => {
+    expect(actions.clean()).to.deep.equal({
+      batch: false,
+      type: 'TEST/ACTION/CLEAN',
+      meta: { id: ID, type: 'ACTION/CLEAN' }
     });
   });
 });

--- a/test/util/createBatchActions.test.js
+++ b/test/util/createBatchActions.test.js
@@ -25,7 +25,8 @@ describe('createBatchActions', () => {
       RESET: 'BATCH/RESET',
       CANCEL: 'BATCH/CANCEL',
       SUCCESS: 'BATCH/SUCCESS',
-      FAILURE: 'BATCH/FAILURE'
+      FAILURE: 'BATCH/FAILURE',
+      CLEAN: 'BATCH/CLEAN'
     });
   });
 
@@ -56,6 +57,15 @@ describe('createBatchActions', () => {
       type: 'BATCH/CANCEL',
       meta: { id: BATCH_ID, type: 'BATCH/CANCEL' },
       payload: { calls: { one: actions1.cancel(), two: actions2.cancel() } }
+    });
+  });
+
+  it('defines a clean function', () => {
+    expect(actions.clean()).to.deep.equal({
+      batch: true,
+      type: 'BATCH/CLEAN',
+      meta: { id: BATCH_ID, type: 'BATCH/CLEAN' },
+      payload: { calls: { one: actions1.clean(), two: actions2.clean() } }
     });
   });
 });


### PR DESCRIPTION
This adds a new `clean` action, which can be used to completely remove state data from the redux store.