### PR TITLE
Fixed progress calculation for batch actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0
+- Fixed `withProgress` HOC for batch actions that have not had `withCall` performed on them
+  previously.  This fixes a scenario where `withCall` is performed on two or more individual
+  actions followed by `withProgress` on a batch action comprised of the previous actions.
+
 # 1.2.1
 - Fixed `clean` action not being handled by reducer.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spunky",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Lifecycle management for react-redux",
   "main": "lib/index.js",
   "repository": "https://github.com/neoverse/spunky",

--- a/src/util/createActions.js
+++ b/src/util/createActions.js
@@ -46,5 +46,5 @@ export default function createActions(id: string, createAdaptor: Function): Acti
     meta: { type: ACTION_CLEAN, id }
   });
 
-  return { id, call, cancel, reset, clean, actionTypes };
+  return { id, call, cancel, reset, clean, actionTypes, batch: false };
 }

--- a/src/util/createBatchActions.js
+++ b/src/util/createBatchActions.js
@@ -64,5 +64,5 @@ export default function createBatchActions(id: string, actionsMap: Object): Acti
     payload: { calls: mapActions(actionsMap, 'clean') }
   });
 
-  return { id, call, cancel, reset, clean, actionTypes };
+  return { id, call, cancel, reset, clean, actionTypes, batch: true, actions: actionsMap };
 }

--- a/src/values/types.js
+++ b/src/values/types.js
@@ -22,7 +22,11 @@ export type ActionName = 'call' | 'cancel' | 'reset' | 'clean';
 
 export type Actions = {
   id: string,
+  batch: boolean,
   actionTypes: ActionTypeMap,
+  actions?: {
+    [name: string]: Actions
+  },
   [name: ActionName]: Function
 };
 


### PR DESCRIPTION
If `withCall` is performed on two or more individual actions followed by `withProgress` on a batch action comprised of the previous actions, the batch action was being treated as if it was comprised of *no* actions.  This is because it has no entry in the redux store due to the `call` action never being called.

This fixes that behavior by storing the fact that a batch is a batch on the action object itself, along with a mapping of any child actions.  This can be traversed directly (without the redux store) within `withProgress`.  This also impacts any HOC that depends on `withProgress` (e.g.: `withProgressComponents`).