### PR TITLE
Fixed progress calculation for unstarted actions as part of a batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.1
+- Fixed `withProgress` HOC for batch actions where any associated actions have not had `withCall`
+  performed on them previously.
+
 # 1.3.0
 - Fixed `withProgress` HOC for batch actions that have not had `withCall` performed on them
   previously.  This fixes a scenario where `withCall` is performed on two or more individual

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spunky",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Lifecycle management for react-redux",
   "main": "lib/index.js",
   "repository": "https://github.com/neoverse/spunky",

--- a/src/hocs/withProgress.js
+++ b/src/hocs/withProgress.js
@@ -1,10 +1,11 @@
 // @flow
 import { type ComponentType } from 'react';
-import { get, map, uniq, reduce, compact } from 'lodash';
+import { get, map, flatten, uniq, reduce } from 'lodash';
 import { connect, type MapStateToProps } from 'react-redux';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
 
 import initiallyLoadedStrategy from './progressStrategies/initiallyLoadedStrategy';
+import { initialState } from '../reducers/actionReducer';
 import { type Actions, type ActionState, type Progress } from '../values/types';
 
 type Options = {
@@ -18,10 +19,10 @@ const getActionIds = (actions: Actions): Array<string> => {
     return [actions.id];
   }
 
-  return uniq(reduce(actions.actions, (ids, childActions) => {
+  return uniq(flatten(reduce(actions.actions, (ids, childActions) => {
     ids.push(getActionIds(childActions));
     return ids;
-  }, []));
+  }, [])));
 };
 
 export default function withProgress(
@@ -35,7 +36,7 @@ export default function withProgress(
   });
 
   const getActionStates = (state: Object): Array<ActionState> => {
-    return compact(map(actionIds, (id) => get(state, `${prefix}.${id}`)));
+    return map(actionIds, (id) => get(state, `${prefix}.${id}`, initialState));
   };
 
   const mapStateToProps: MapStateToProps<*, *, *> = (state: Object): Object => {

--- a/src/reducers/actionReducer.js
+++ b/src/reducers/actionReducer.js
@@ -21,7 +21,7 @@ type State = {
   error: Error
 };
 
-const initialState: State = {
+export const initialState: State = {
   batch: false,
   progress: INITIAL,
   rollbackProgress: null,


### PR DESCRIPTION
Fixed `withProgress` HOC for batch actions where any associated actions have not had `withCall` performed on them previously.  Bumped version to 1.3.1.