### PR TITLE
Fixed readme component reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ const MyContainer = compose(
 )(MyComponent);
 
 ReactDOM.render(
-  <MyComponent id={1} />,
+  <MyContainer id={1} />,
   document.getElementById("root")
 );
 ```


### PR DESCRIPTION
The README was referencing the wrong React component in the Usage section.